### PR TITLE
Switch build to Maven and improve webhook feedback

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,7 @@
+/build/
+/.gradle/
+/out/
+/bin/
+/.idea/
+*.iml
+/target/

--- a/README.md
+++ b/README.md
@@ -1,1 +1,18 @@
 # BugReportPlugin
+
+Velocity plugin that lets players send bug reports to Discord via a webhook and review open reports in-game.
+
+## Features
+- Configurable language (`de` or `en`), chat prefix and Discord webhook URL via `config.conf`.
+- `/bugreport <reason>` command for players (`net.devvoxel.bugreport.use`).
+- `/bugreports` command to list pending reports (`net.devvoxel.bugreport.*`).
+- Discord embed containing the reporting player, server, coordinates and the submitted reason.
+
+## Building
+Use Maven 3.9+ with JDK 17:
+
+```
+mvn package
+```
+
+The shaded plugin JAR will be available at `target/bugreportplugin-1.0.0-shaded.jar`.

--- a/pom.xml
+++ b/pom.xml
@@ -1,0 +1,72 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>net.devvoxel</groupId>
+    <artifactId>bugreportplugin</artifactId>
+    <version>1.0.0</version>
+    <name>BugReportPlugin</name>
+    <description>Velocity bug report plugin</description>
+
+    <properties>
+        <maven.compiler.source>17</maven.compiler.source>
+        <maven.compiler.target>17</maven.compiler.target>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
+
+    <repositories>
+        <repository>
+            <id>papermc</id>
+            <url>https://repo.papermc.io/repository/maven-public/</url>
+        </repository>
+    </repositories>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.velocitypowered</groupId>
+            <artifactId>velocity-api</artifactId>
+            <version>3.4.0-SNAPSHOT</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.spongepowered</groupId>
+            <artifactId>configurate-hocon</artifactId>
+            <version>4.1.2</version>
+        </dependency>
+        <dependency>
+            <groupId>com.google.code.gson</groupId>
+            <artifactId>gson</artifactId>
+            <version>2.11.0</version>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.13.0</version>
+                <configuration>
+                    <release>17</release>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-shade-plugin</artifactId>
+                <version>3.5.3</version>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>shade</goal>
+                        </goals>
+                        <configuration>
+                            <createDependencyReducedPom>false</createDependencyReducedPom>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/src/main/java/net/devvoxel/bugreport/BugReport.java
+++ b/src/main/java/net/devvoxel/bugreport/BugReport.java
@@ -1,0 +1,41 @@
+package net.devvoxel.bugreport;
+
+import com.velocitypowered.api.proxy.Player;
+
+import java.time.Instant;
+
+public final class BugReport {
+    private final String playerName;
+    private final String serverName;
+    private final String location;
+    private final String reason;
+    private final Instant createdAt;
+
+    public BugReport(Player player, String serverName, String location, String reason) {
+        this.playerName = player.getUsername();
+        this.serverName = serverName;
+        this.location = location;
+        this.reason = reason;
+        this.createdAt = Instant.now();
+    }
+
+    public String getPlayerName() {
+        return playerName;
+    }
+
+    public String getServerName() {
+        return serverName;
+    }
+
+    public String getLocation() {
+        return location;
+    }
+
+    public String getReason() {
+        return reason;
+    }
+
+    public Instant getCreatedAt() {
+        return createdAt;
+    }
+}

--- a/src/main/java/net/devvoxel/bugreport/BugReportCommand.java
+++ b/src/main/java/net/devvoxel/bugreport/BugReportCommand.java
@@ -1,0 +1,53 @@
+package net.devvoxel.bugreport;
+
+import com.velocitypowered.api.command.SimpleCommand;
+import com.velocitypowered.api.proxy.Player;
+
+import java.util.List;
+
+public final class BugReportCommand implements SimpleCommand {
+    private static final String PERMISSION = "net.devvoxel.bugreport.use";
+
+    private final BugReportPlugin plugin;
+
+    public BugReportCommand(BugReportPlugin plugin) {
+        this.plugin = plugin;
+    }
+
+    @Override
+    public void execute(Invocation invocation) {
+        if (!(invocation.source() instanceof Player player)) {
+            plugin.sendPrefixedMessage(invocation.source(), plugin.getMessages().get("command-only-player"));
+            return;
+        }
+
+        if (!invocation.source().hasPermission(PERMISSION) && !invocation.source().hasPermission("net.devvoxel.bugreport.*")) {
+            plugin.sendPrefixedMessage(invocation.source(), plugin.getMessages().get("command-no-permission"));
+            return;
+        }
+
+        String[] args = invocation.arguments();
+        if (args.length == 0) {
+            plugin.sendPrefixedMessage(invocation.source(), plugin.getMessages().get("report-usage"));
+            return;
+        }
+
+        String reason = String.join(" ", args).trim();
+        if (reason.isEmpty()) {
+            plugin.sendPrefixedMessage(invocation.source(), plugin.getMessages().get("report-too-short"));
+            return;
+        }
+
+        plugin.handleBugReport(player, reason);
+    }
+
+    @Override
+    public List<String> suggest(Invocation invocation) {
+        return List.of();
+    }
+
+    @Override
+    public boolean hasPermission(Invocation invocation) {
+        return invocation.source().hasPermission(PERMISSION) || invocation.source().hasPermission("net.devvoxel.bugreport.*");
+    }
+}

--- a/src/main/java/net/devvoxel/bugreport/BugReportConfig.java
+++ b/src/main/java/net/devvoxel/bugreport/BugReportConfig.java
@@ -1,0 +1,80 @@
+package net.devvoxel.bugreport;
+
+import org.spongepowered.configurate.CommentedConfigurationNode;
+import org.spongepowered.configurate.ConfigurateException;
+import org.spongepowered.configurate.hocon.HoconConfigurationLoader;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+public final class BugReportConfig {
+    private static final String DEFAULT_LANGUAGE = "de";
+    private static final String DEFAULT_PREFIX = "&bBugReportSystem &8» &r";
+    private static final String DEFAULT_WEBHOOK = "dein webhook";
+
+    private final Path filePath;
+    private final HoconConfigurationLoader loader;
+
+    private CommentedConfigurationNode root;
+
+    public BugReportConfig(Path dataDirectory) {
+        this.filePath = dataDirectory.resolve("config.conf");
+        this.loader = HoconConfigurationLoader.builder().path(filePath).build();
+    }
+
+    public void load() throws ConfigurateException, IOException {
+        Files.createDirectories(filePath.getParent());
+        if (Files.notExists(filePath)) {
+            root = createDefaultNode();
+            loader.save(root);
+            return;
+        }
+
+        root = loader.load();
+        boolean changed = false;
+        if (root.node("language").virtual()) {
+            root.node("language").set(DEFAULT_LANGUAGE);
+            changed = true;
+        }
+        if (root.node("prefix").virtual()) {
+            root.node("prefix").set(DEFAULT_PREFIX);
+            changed = true;
+        }
+        if (root.node("webhook").virtual()) {
+            root.node("webhook").set(DEFAULT_WEBHOOK);
+            changed = true;
+        }
+        if (changed) {
+            loader.save(root);
+        }
+    }
+
+    public void useDefaults() {
+        try {
+            root = createDefaultNode();
+        } catch (ConfigurateException e) {
+            throw new IllegalStateException("Unable to create default configuration", e);
+        }
+    }
+
+    private CommentedConfigurationNode createDefaultNode() throws ConfigurateException {
+        CommentedConfigurationNode node = loader.createNode();
+        node.node("language").set(DEFAULT_LANGUAGE);
+        node.node("prefix").set(DEFAULT_PREFIX);
+        node.node("webhook").set(DEFAULT_WEBHOOK);
+        return node;
+    }
+
+    public String getLanguage() {
+        return root.node("language").getString(DEFAULT_LANGUAGE).trim().toLowerCase();
+    }
+
+    public String getPrefix() {
+        return root.node("prefix").getString(DEFAULT_PREFIX);
+    }
+
+    public String getWebhook() {
+        return root.node("webhook").getString(DEFAULT_WEBHOOK);
+    }
+}

--- a/src/main/java/net/devvoxel/bugreport/BugReportMessages.java
+++ b/src/main/java/net/devvoxel/bugreport/BugReportMessages.java
@@ -1,0 +1,57 @@
+package net.devvoxel.bugreport;
+
+import java.util.Locale;
+import java.util.Map;
+
+public final class BugReportMessages {
+    private static final Map<String, Map<String, String>> TRANSLATIONS = Map.of(
+        "de", Map.ofEntries(
+            Map.entry("report-usage", "&cBenutze: /bugreport <grund>"),
+            Map.entry("report-too-short", "&cBitte gib einen Grund für den Bugreport an."),
+            Map.entry("report-sent", "&aDein Bugreport wurde gesendet."),
+            Map.entry("report-failed", "&cBeim Versenden des Bugreports ist ein Fehler aufgetreten. Bitte informiere das Team."),
+            Map.entry("report-notify", "&e%player% &7hat einen Bug gemeldet: &f%reason%"),
+            Map.entry("reports-header", "&bAktuelle Bugreports:"),
+            Map.entry("reports-empty", "&7Es wurden noch keine Bugreports erstellt."),
+            Map.entry("reports-entry", "&8- &b%player% &7auf &f%server% &7(&f%location%&7): &f%reason%"),
+            Map.entry("embed-username", "Username"),
+            Map.entry("embed-server", "Aktueller Server"),
+            Map.entry("embed-location", "Position"),
+            Map.entry("embed-reason", "Bug"),
+            Map.entry("command-no-permission", "&cDu hast keine Berechtigung für diesen Befehl."),
+            Map.entry("command-only-player", "&cNur Spieler können diesen Befehl verwenden."),
+            Map.entry("reports-title", "Bugreports"),
+            Map.entry("embed-title", "Neuer Bugreport"),
+            Map.entry("reports-open-count", "&7Anzahl offener Reports: &b%count%")
+        ),
+        "en", Map.ofEntries(
+            Map.entry("report-usage", "&cUsage: /bugreport <reason>"),
+            Map.entry("report-too-short", "&cPlease provide a reason for your bug report."),
+            Map.entry("report-sent", "&aYour bug report has been sent."),
+            Map.entry("report-failed", "&cAn error occurred while sending the bug report. Please contact the staff."),
+            Map.entry("report-notify", "&e%player% &7reported a bug: &f%reason%"),
+            Map.entry("reports-header", "&bCurrent bug reports:"),
+            Map.entry("reports-empty", "&7No bug reports have been submitted yet."),
+            Map.entry("reports-entry", "&8- &b%player% &7on &f%server% &7(&f%location%&7): &f%reason%"),
+            Map.entry("embed-username", "Username"),
+            Map.entry("embed-server", "Current Server"),
+            Map.entry("embed-location", "Location"),
+            Map.entry("embed-reason", "Bug"),
+            Map.entry("command-no-permission", "&cYou do not have permission to use this command."),
+            Map.entry("command-only-player", "&cOnly players can use this command."),
+            Map.entry("reports-title", "Bug Reports"),
+            Map.entry("embed-title", "New Bug Report"),
+            Map.entry("reports-open-count", "&7Open reports: &b%count%")
+        )
+    );
+
+    private final Map<String, String> messages;
+
+    public BugReportMessages(String language) {
+        this.messages = TRANSLATIONS.getOrDefault(language.toLowerCase(Locale.ROOT), TRANSLATIONS.get("en"));
+    }
+
+    public String get(String key) {
+        return messages.getOrDefault(key, key);
+    }
+}

--- a/src/main/java/net/devvoxel/bugreport/BugReportPlugin.java
+++ b/src/main/java/net/devvoxel/bugreport/BugReportPlugin.java
@@ -1,0 +1,179 @@
+package net.devvoxel.bugreport;
+
+import com.google.gson.JsonArray;
+import com.google.gson.JsonObject;
+import com.velocitypowered.api.command.CommandManager;
+import com.velocitypowered.api.event.Subscribe;
+import com.velocitypowered.api.event.proxy.ProxyInitializeEvent;
+import com.velocitypowered.api.plugin.Plugin;
+import com.velocitypowered.api.plugin.annotation.DataDirectory;
+import com.velocitypowered.api.proxy.Player;
+import com.velocitypowered.api.proxy.ProxyServer;
+import com.velocitypowered.api.util.Position;
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer;
+import org.spongepowered.configurate.ConfigurateException;
+import org.slf4j.Logger;
+
+import javax.inject.Inject;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Path;
+import java.time.format.DateTimeFormatter;
+import java.util.List;
+import java.util.Locale;
+import java.util.Objects;
+import java.util.concurrent.CopyOnWriteArrayList;
+
+@Plugin(id = "bugreportplugin", name = "BugReportPlugin", version = "1.0.0", authors = {"devvoxel"})
+public final class BugReportPlugin {
+    private static final LegacyComponentSerializer LEGACY_SERIALIZER = LegacyComponentSerializer.legacyAmpersand();
+    private static final DateTimeFormatter ISO_FORMATTER = DateTimeFormatter.ISO_INSTANT;
+
+    private final ProxyServer proxyServer;
+    private final Logger logger;
+    private final Path dataDirectory;
+
+    private final HttpClient httpClient = HttpClient.newBuilder().build();
+    private final List<BugReport> reports = new CopyOnWriteArrayList<>();
+
+    private BugReportConfig config;
+    private BugReportMessages messages;
+
+    @Inject
+    public BugReportPlugin(ProxyServer proxyServer, Logger logger, @DataDirectory Path dataDirectory) {
+        this.proxyServer = proxyServer;
+        this.logger = logger;
+        this.dataDirectory = dataDirectory;
+    }
+
+    @Subscribe
+    public void onProxyInitialize(ProxyInitializeEvent event) {
+        this.config = new BugReportConfig(dataDirectory);
+        try {
+            config.load();
+        } catch (ConfigurateException | java.io.IOException e) {
+            logger.error("Unable to load bug report configuration", e);
+            config.useDefaults();
+        }
+        this.messages = new BugReportMessages(config.getLanguage());
+
+        CommandManager commandManager = proxyServer.getCommandManager();
+        commandManager.register(commandManager.metaBuilder("bugreport").plugin(this).build(), new BugReportCommand(this));
+        commandManager.register(commandManager.metaBuilder("bugreports").plugin(this).build(), new BugReportsCommand(this));
+
+        logger.info("BugReportPlugin has been enabled");
+    }
+
+    public BugReportMessages getMessages() {
+        return messages;
+    }
+
+    public List<BugReport> getReports() {
+        return reports;
+    }
+
+    public void handleBugReport(Player player, String reason) {
+        String serverName = player.getCurrentServer()
+            .map(connection -> connection.getServerInfo().getName())
+            .orElse("Unknown");
+        Position position = player.getPosition();
+        String location = String.format(Locale.ROOT, "%.2f, %.2f, %.2f", position.getX(), position.getY(), position.getZ());
+
+        BugReport report = new BugReport(player, serverName, location, reason);
+        reports.add(report);
+
+        sendPrefixedMessage(player, messages.get("report-sent"));
+        notifyStaff(report, player);
+        dispatchWebhook(report, player);
+    }
+
+    private void notifyStaff(BugReport report, Player sender) {
+        String message = messages.get("report-notify")
+            .replace("%player%", sender.getUsername())
+            .replace("%reason%", report.getReason());
+        Component component = LEGACY_SERIALIZER.deserialize(config.getPrefix() + message);
+        proxyServer.getAllPlayers().stream()
+            .filter(player -> player.hasPermission("net.devvoxel.bugreport.*"))
+            .forEach(player -> player.sendMessage(component));
+    }
+
+    private void dispatchWebhook(BugReport report, Player sender) {
+        String webhook = Objects.requireNonNullElse(config.getWebhook(), "").trim();
+        if (webhook.isEmpty() || webhook.equalsIgnoreCase("dein webhook")) {
+            logger.warn("Webhook URL is not configured. Skipping Discord notification for bug reports.");
+            return;
+        }
+
+        JsonObject payload = new JsonObject();
+        payload.addProperty("username", "BugReportSystem");
+        payload.addProperty("content", "");
+
+        JsonObject embed = new JsonObject();
+        embed.addProperty("title", messages.get("embed-title"));
+        embed.addProperty("description", messages.get("embed-reason") + ": " + report.getReason());
+        embed.addProperty("color", 4592639);
+        embed.addProperty("timestamp", ISO_FORMATTER.format(report.getCreatedAt()));
+
+        JsonArray fields = new JsonArray();
+
+        JsonObject usernameField = new JsonObject();
+        usernameField.addProperty("name", messages.get("embed-username"));
+        usernameField.addProperty("value", report.getPlayerName());
+        usernameField.addProperty("inline", false);
+        fields.add(usernameField);
+
+        JsonObject serverField = new JsonObject();
+        serverField.addProperty("name", messages.get("embed-server"));
+        serverField.addProperty("value", report.getServerName());
+        serverField.addProperty("inline", false);
+        fields.add(serverField);
+
+        JsonObject locationField = new JsonObject();
+        locationField.addProperty("name", messages.get("embed-location"));
+        locationField.addProperty("value", report.getLocation());
+        locationField.addProperty("inline", false);
+        fields.add(locationField);
+
+        embed.add("fields", fields);
+
+        JsonArray embeds = new JsonArray();
+        embeds.add(embed);
+        payload.add("embeds", embeds);
+
+        HttpRequest request = HttpRequest.newBuilder()
+            .uri(URI.create(webhook))
+            .header("Content-Type", "application/json")
+            .POST(HttpRequest.BodyPublishers.ofString(payload.toString(), StandardCharsets.UTF_8))
+            .build();
+
+        httpClient.sendAsync(request, HttpResponse.BodyHandlers.discarding())
+            .whenComplete((response, throwable) -> {
+                if (throwable != null) {
+                    logger.error("Failed to deliver bug report to Discord webhook", throwable);
+                    notifyDeliveryFailure(sender);
+                    return;
+                }
+
+                if (response.statusCode() >= 300) {
+                    logger.error("Discord webhook responded with status {} when delivering bug report", response.statusCode());
+                    notifyDeliveryFailure(sender);
+                }
+            });
+    }
+
+    private void notifyDeliveryFailure(Player sender) {
+        proxyServer.getScheduler().buildTask(this, () ->
+            proxyServer.getPlayer(sender.getUniqueId())
+                .ifPresent(player -> sendPrefixedMessage(player, messages.get("report-failed")))
+        ).schedule();
+    }
+
+    public void sendPrefixedMessage(com.velocitypowered.api.command.CommandSource target, String message) {
+        Component component = LEGACY_SERIALIZER.deserialize(config.getPrefix() + message);
+        target.sendMessage(component);
+    }
+}

--- a/src/main/java/net/devvoxel/bugreport/BugReportsCommand.java
+++ b/src/main/java/net/devvoxel/bugreport/BugReportsCommand.java
@@ -1,0 +1,49 @@
+package net.devvoxel.bugreport;
+
+import com.velocitypowered.api.command.SimpleCommand;
+
+import java.util.List;
+
+public final class BugReportsCommand implements SimpleCommand {
+    private static final String PERMISSION = "net.devvoxel.bugreport.*";
+
+    private final BugReportPlugin plugin;
+
+    public BugReportsCommand(BugReportPlugin plugin) {
+        this.plugin = plugin;
+    }
+
+    @Override
+    public void execute(Invocation invocation) {
+        if (!invocation.source().hasPermission(PERMISSION)) {
+            plugin.sendPrefixedMessage(invocation.source(), plugin.getMessages().get("command-no-permission"));
+            return;
+        }
+
+        List<BugReport> reports = plugin.getReports();
+        if (reports.isEmpty()) {
+            plugin.sendPrefixedMessage(invocation.source(), plugin.getMessages().get("reports-empty"));
+            return;
+        }
+
+        plugin.sendPrefixedMessage(invocation.source(), plugin.getMessages().get("reports-header"));
+        plugin.sendPrefixedMessage(invocation.source(), plugin.getMessages().get("reports-open-count").replace("%count%", Integer.toString(reports.size())));
+        reports.forEach(report -> plugin.sendPrefixedMessage(invocation.source(),
+            plugin.getMessages().get("reports-entry")
+                .replace("%player%", report.getPlayerName())
+                .replace("%server%", report.getServerName())
+                .replace("%location%", report.getLocation())
+                .replace("%reason%", report.getReason())
+        ));
+    }
+
+    @Override
+    public List<String> suggest(Invocation invocation) {
+        return List.of();
+    }
+
+    @Override
+    public boolean hasPermission(Invocation invocation) {
+        return invocation.source().hasPermission(PERMISSION);
+    }
+}

--- a/src/main/resources/velocity-plugin.json
+++ b/src/main/resources/velocity-plugin.json
@@ -1,0 +1,8 @@
+{
+  "id": "bugreportplugin",
+  "name": "BugReportPlugin",
+  "version": "1.0.0",
+  "main": "net.devvoxel.bugreport.BugReportPlugin",
+  "authors": ["devvoxel"],
+  "dependencies": []
+}


### PR DESCRIPTION
## Summary
- replace the Gradle wrapper with a Maven build to avoid committing binary wrapper files while still shading dependencies
- simplify `/bugreport` reason parsing and inform players if Discord webhook delivery fails
- document Maven build usage in the README

## Testing
- `mvn -q -DskipTests package` *(fails: status code 403 when downloading Maven plugin via proxy)*

------
https://chatgpt.com/codex/tasks/task_e_68de56806358832e8e3c3caa35b2889b