### PR TITLE
Exclude signed metadata when shading dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -63,6 +63,16 @@
                         </goals>
                         <configuration>
                             <createDependencyReducedPom>false</createDependencyReducedPom>
+                            <filters>
+                                <filter>
+                                    <artifact>*:*</artifact>
+                                    <excludes>
+                                        <exclude>META-INF/*.SF</exclude>
+                                        <exclude>META-INF/*.DSA</exclude>
+                                        <exclude>META-INF/*.RSA</exclude>
+                                    </excludes>
+                                </filter>
+                            </filters>
                         </configuration>
                     </execution>
                 </executions>


### PR DESCRIPTION
## Summary
- exclude signature metadata from shaded dependencies to prevent invalid jar signature errors at runtime

## Testing
- `mvn -q package` *(fails: 403 Forbidden fetching maven-resources-plugin)*

------
https://chatgpt.com/codex/tasks/task_e_68de62ada894832eb2851548ff0d061f